### PR TITLE
improve the wording of preset_uploaders.yaml

### DIFF
--- a/lib/assets/preset_uploaders.yaml
+++ b/lib/assets/preset_uploaders.yaml
@@ -11,16 +11,17 @@
 #   - Headers: Additional headers to include in the request
 #   - Parameters: Additional parameters to include in the request
 #   - Arguments: Additional arguments for the request (form data)
-#   - URLResponse: How the app should parse the returned url from the server. Custom Uploader will attempt
-#     to get the returned url automatically, but some services may break up the returned url, in
-#     which case this field should be used
+#   - URLResponse: How the app should parse the returned url from the server. Custom Uploader will 
+#     attempt to get the returned url automatically, but some services may break up the returned url, 
+#     in which case this field should be used
 #   - ErrorResponse: How the app should parse the error returned from the server in case the upload
 #     failed
 #   - RequestMethod*: The HTTP request method to use (POST, PUT, GET, PATCH)
 #
 # Each preset may have a different set of fields depending on the service.
 # Additionally, fields marked with an "*" are required.
-# Feel free to add more presets following the same structure.
+#
+# Feel free to contribute more presets by following the same structure :)
 
 ###################################################################################################
 
@@ -67,4 +68,4 @@
     api_option: "paste"
     api_paste_name: "Custom Uploader Paste"
   RequestMethod: "POST"
-  ErrorResponse: "$response$"
+  ErrorResponse: "$regex:.*$"


### PR DESCRIPTION
While this does improve the wording of the block comment in the yaml file, this is also a **_test_** to see if I can open PR's in my own repository because after I have recently added depenadbot to it, I kept getting errors from it saying: `POST https://api.github.com/repos/SrS2225a/custom_uploader/git/trees: 422 - GitRPC::BadObjectState // See: https://docs.github.com/rest/git/trees#create-a-tree` upon each update check. So because of this, I now have a bit of a suspension that other users cannot actually open pull requests themselves, especially since this repository already have over 50 starts and still no PR's from other users. So I am testing to see if I can create PR's for my repository. I am already in contact with Github about this